### PR TITLE
ui: add responsive action buttons

### DIFF
--- a/src/components/controls/LikeControl.tsx
+++ b/src/components/controls/LikeControl.tsx
@@ -1,8 +1,13 @@
 import React from "react"
 import { useState } from "react"
 
-import { Text, Button, ButtonGroup, useToast } from "@chakra-ui/react"
-import { HandThumbsUp } from "~/src/components/utils/Icons"
+import { Text, Button, ButtonGroup, Box, useToast } from "@chakra-ui/react"
+import {
+  HandThumbsDown,
+  HandThumbsDownFill,
+  HandThumbsUp,
+  HandThumbsUpFill,
+} from "~/src/components/utils/Icons"
 import { handleError } from "~/src/utils"
 
 export default function useLikeControl({
@@ -56,7 +61,7 @@ export default function useLikeControl({
 
   return [
     <Text fontSize="sm">
-      <HandThumbsUp />{" "}
+      <HandThumbsUpFill />{" "}
       {clientCurrentLike +
         (whetherLike !== null ? whetherLike - clientWhetherLike : 0)}
     </Text>,
@@ -81,5 +86,21 @@ export default function useLikeControl({
         踩
       </Button>
     </ButtonGroup>,
+    <Text fontSize="sm">
+      <span onClick={toggleLikePost}>
+        {whetherLikeCombined === 1 ? <HandThumbsUpFill /> : <HandThumbsUp />}
+      </span>
+      &nbsp;
+      {clientCurrentLike +
+        (whetherLike !== null ? whetherLike - clientWhetherLike : 0)}
+      &nbsp;&nbsp;&nbsp;
+      <span onClick={toggleDislikePost}>
+        {whetherLikeCombined === -1 ? (
+          <HandThumbsDownFill />
+        ) : (
+          <HandThumbsDown />
+        )}
+      </span>
+    </Text>,
   ]
 }

--- a/src/components/elements/Floor.tsx
+++ b/src/components/elements/Floor.tsx
@@ -2,6 +2,7 @@ import React from "react"
 
 import {
   Stack,
+  HStack,
   Box,
   Text,
   Button,
@@ -13,7 +14,7 @@ import {
 } from "@chakra-ui/react"
 import { Floor, useClient } from "~/src/client"
 import {
-  HandThumbsUp,
+  HandThumbsUpFill,
   ArrowRight,
   Flag,
   ReplyFill,
@@ -43,10 +44,10 @@ export function FloorSkeleton() {
           <SkeletonText spacing="4" />
         </Stack>
       </Box>
-      <Box size="80px" p="3">
+      <Box size="80px" p="3" display={{ base: "none", sm: "unset" }}>
         <Stack color="teal.500" width="80px">
           <Text fontSize="sm">
-            <HandThumbsUp />
+            <HandThumbsUpFill />
           </Text>
         </Stack>
       </Box>
@@ -64,7 +65,11 @@ export function FloorComponent({
 }: FloorComponentProps) {
   const client = useClient()
   const payload = { postId: threadId, replyId: floor.FloorID }
-  const [likeTextControl, likeButtonControl] = useLikeControl({
+  const [
+    likeTextControl,
+    likeButtonControl,
+    likeTextButtonControl,
+  ] = useLikeControl({
     clientWhetherLike: floor.WhetherLike,
     clientCurrentLike: floor.Like - floor.Dislike,
     onCancelLike: () => client.cancelLikeReply(payload),
@@ -120,9 +125,30 @@ export function FloorComponent({
             {floor.Context}
           </Text>
         </Stack>
+
+        {showControl && (
+          <Box display={{ base: "block", sm: "none" }} paddingTop={3}>
+            <Stack color="teal.500">
+              <HStack justifyContent="space-between">
+                {likeTextButtonControl}
+                <HStack>
+                  {reportControl}
+                  <Button
+                    colorScheme="teal"
+                    size="xs"
+                    variant="outline"
+                    onClick={() => onReply(floor)}
+                  >
+                    <ReplyFill /> &nbsp; 回复
+                  </Button>
+                </HStack>
+              </HStack>
+            </Stack>
+          </Box>
+        )}
       </Box>
       {showControl && (
-        <Box size="80px" p="3">
+        <Box size="80px" p="3" display={{ base: "none", sm: "unset" }}>
           <Stack color="teal.500" width="80px">
             {likeTextControl}
             {likeButtonControl}

--- a/src/components/elements/Thread.tsx
+++ b/src/components/elements/Thread.tsx
@@ -2,6 +2,9 @@ import React from "react"
 
 import {
   Stack,
+  HStack,
+  Wrap,
+  WrapItem,
   Box,
   Heading,
   Text,
@@ -14,7 +17,7 @@ import {
 } from "@chakra-ui/react"
 import { Thread, useClient } from "~/src/client"
 import {
-  HandThumbsUp,
+  HandThumbsUpFill,
   ChatSquareText,
   Flag,
   Broadcast,
@@ -49,10 +52,10 @@ export function ThreadSkeleton({ showControl }: ThreadSkeletonProps) {
           <SkeletonText spacing="3" noOfLines="4" />
         </Stack>
       </Box>
-      <Box size="80px" p="3">
+      <Box size="80px" p="3" display={{ base: "none", sm: "unset" }}>
         <Stack color="teal.500" width="80px">
           <Text fontSize="sm">
-            <HandThumbsUp />
+            <HandThumbsUpFill />
           </Text>
           <Text fontSize="sm">
             <ChatSquareText />
@@ -151,9 +154,43 @@ export function ThreadComponent({
           <Text mt={4} wordBreak="break-word">
             {thread.Summary}
           </Text>
+
+          <Box display={{ base: "block", sm: "none" }}>
+            <Stack color="teal.500">
+              <HStack justifyContent="space-between">
+                {likeTextControl}
+                <HStack>
+                  <Text fontSize="sm">
+                    <ChatSquareText /> {thread.Comment}
+                  </Text>
+                  <Text fontSize="sm">
+                    <Broadcast /> {thread.Read}
+                  </Text>
+                </HStack>
+              </HStack>
+
+              {showControl && (
+                <HStack justifyContent="space-between">
+                  {likeButtonControl}
+                  <HStack>
+                    {favourControl}
+                    {reportControl}
+                    <Button
+                      colorScheme="teal"
+                      size="xs"
+                      variant="outline"
+                      onClick={onReply}
+                    >
+                      <ReplyFill /> &nbsp; 回复
+                    </Button>
+                  </HStack>
+                </HStack>
+              )}
+            </Stack>
+          </Box>
         </Stack>
       </Box>
-      <Box size="80px" p="3">
+      <Box size="80px" p="3" display={{ base: "none", sm: "unset" }}>
         <Stack color="teal.500" width="80px">
           {likeTextControl}
           <Text fontSize="sm">

--- a/src/components/utils/Icons.tsx
+++ b/src/components/utils/Icons.tsx
@@ -24,8 +24,20 @@ export function ArrowRightCircleFill() {
   return <i className="bi bi-arrow-right-circle-fill" />
 }
 
-export function HandThumbsUp() {
+export function HandThumbsUpFill() {
   return <i className="bi bi-hand-thumbs-up-fill" />
+}
+
+export function HandThumbsUp() {
+  return <i className="bi bi-hand-thumbs-up" />
+}
+
+export function HandThumbsDownFill() {
+  return <i className="bi bi-hand-thumbs-down-fill" />
+}
+
+export function HandThumbsDown() {
+  return <i className="bi bi-hand-thumbs-down" />
 }
 
 export function ChatSquareText() {


### PR DESCRIPTION
Move action buttons to the bottom of card when viewing on `sm` size screen.

<details>
<summary>screenshots</summary>

![image](https://user-images.githubusercontent.com/7235968/114066608-79dacf00-98ce-11eb-9c41-6f177a984073.png)

----

![image](https://user-images.githubusercontent.com/7235968/114066669-8f4ff900-98ce-11eb-8e7a-781ef845d5e7.png)

</details>