### PR TITLE
ui: improve token textarea

### DIFF
--- a/src/components/views/Login.tsx
+++ b/src/components/views/Login.tsx
@@ -270,6 +270,8 @@ function Login() {
                     <Textarea
                       value={token}
                       onChange={(event) => setToken(event.target.value)}
+                      rows={5}
+                      onFocus={(e) => e.target.select()}
                     />
                   </FormControl>
                   <Button mt={4} colorScheme="blue" onClick={setTokenSetting}>


### PR DESCRIPTION
Resolve #24 .

We get to a compromise proposal:

1. Select all text after `textarea` getting focus.
2. Set initial rows of 5 to ensure token is displayed completely at least on PC.